### PR TITLE
Fix a NULL ptr dereference from v8 qemu RFC patch.

### DIFF
--- a/src/include/qnio_api.h
+++ b/src/include/qnio_api.h
@@ -24,9 +24,6 @@
 #define IOR_VDISK_FLUSH                     2019
 #define IOR_VDISK_CHECK_IO_FAILOVER_READY   IRP_VDISK_CHECK_IO_FAILOVER_READY
 
-#define VXHS_VECTOR_ALIGNED                 0
-#define VXHS_VECTOR_NOT_ALIGNED             -1
-
 #define QNIOERROR_RETRY_ON_SOURCE           44
 #define QNIOERROR_HUP                       901
 #define QNIOERROR_NOCONN                    902

--- a/src/lib/qnio/nioapi.c
+++ b/src/lib/qnio/nioapi.c
@@ -433,11 +433,10 @@ iio_ioctl(void *ctx, int32_t rfd, uint32_t opcode,
     int ret = 0;
     char *out = NULL;
 
-    *vdisk_size = 0;
-
     switch (opcode)
     {
         case IOR_VDISK_STAT:
+            *vdisk_size = 0;
 	    ret = iio_ioctl_json(apictx, rfd, IOR_VDISK_STAT, NULL, &out, NULL, flags);
 	    if (ret == QNIOERROR_SUCCESS)
 	    {
@@ -447,6 +446,7 @@ iio_ioctl(void *ctx, int32_t rfd, uint32_t opcode,
             break;
 
         case IOR_VDISK_FLUSH:
+            *vdisk_size = 0;
             ret = iio_ioctl_json(apictx, rfd, IOR_VDISK_FLUSH, NULL, &out, NULL, flags);
             break;
 
@@ -460,7 +460,6 @@ iio_ioctl(void *ctx, int32_t rfd, uint32_t opcode,
     {
 	qnioDbg("Error while executing the IOCTL. Opcode = %u\n",
 		  opcode);
-        *vdisk_size = 0;
 	ret = -EIO;
     }
 


### PR DESCRIPTION
Also removing a macro that we stopped using in v8 qemu patch.
Other changes from qemu review will follow.