### PR TITLE
Changes to go with v5 qemu patch.

### DIFF
--- a/src/lib/qnio/nio_client.c
+++ b/src/lib/qnio/nio_client.c
@@ -437,6 +437,7 @@ qnio_client_init(qnio_notify client_notify)
     /* Initialize slab pools */
     slab_init(&ctx->msg_pool, MSG_POOL_SIZE, sizeof(struct qnio_msg), 0, NULL);
     for(i=0;i<MAX_CLIENT_EPOLL_UNITS+1;i++) {
+        ck_pr_store_int(&(ctx->ceu[i].exit_thread), 0);
         ctx->ceu[i].activefds = calloc(MAXFDS, sizeof event);
         ctx->ceu[i].epoll_fd = epoll_create1(0);
         if(ctx->ceu[i].epoll_fd == -1) {
@@ -466,7 +467,7 @@ qnio_client_fini(struct qnio_ctx *ctx)
 
     nioDbg("Starting client fini"); 
     for(i=0; i < MAX_CLIENT_EPOLL_UNITS+1; i++) {
-        ck_pr_or_int(&(ctx->ceu[i].exit_thread), 1);
+        ck_pr_store_int(&(ctx->ceu[i].exit_thread), 1);
         fd[i] = eventfd(0, EFD_NONBLOCK);
         ep_event.events = EPOLLIN;
         ep_event.data.ptr = NULL;

--- a/src/lib/qnio/nio_server.c
+++ b/src/lib/qnio/nio_server.c
@@ -242,8 +242,7 @@ server_recv_epoll(void *args)
 
                 /* Ding send epoll for cleanup */
                 e->conn->ev.io_class->write(&e->conn->ev, NULL, 0);
-            }
-            else if (eu->recv_activefds[i].events & EPOLLIN) {
+            } else if (eu->recv_activefds[i].events & EPOLLIN) {
                 e = (struct endpoint *)eu->recv_activefds[i].data.ptr;
                 process_incoming_messages(e->conn);
 
@@ -425,10 +424,6 @@ qnio_send_resp(struct qnio_msg *msg)
     pthread_mutex_lock(&c->msg_lock);
     LIST_DEL(&msg->lnode);
     pthread_mutex_unlock(&c->msg_lock);
-    if (msg->hinfo.payload_size > IO_BUF_SIZE) {
-        /* return payload too big */
-        return (QNIOERROR_INVALIDARG);
-    }
     if (c == NULL || (ck_pr_load_int(&c->flags) & CONN_FLAG_DISCONNECTED)) {
         nioDbg("Server side connection is disconnected. Not enqueuing response.");
         /*


### PR DESCRIPTION
1. Initialize exit_thread field in qnio_client_epoll_unit structure.
2. Remove IO_BUF_SIZE limit in qnio_send_resp().