### PR TITLE
Changes to go with v6 qemu patch series

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,6 @@
 all:
 
+MAKEFILE = Makefile
 SHELL = /bin/sh
 CC    = gcc
 
@@ -9,10 +10,11 @@ DEPFLAGS     = -MMD -MP -MT $@ -MF $(@D)/$(*F).d
 LDFLAGS      = -shared
 DEBUGFLAGS   = -O0 -D_DEBUG -D_REENTRANT
 RELEASEFLAGS = -03 -D_REENTRANT
+HEADERS      = /usr/include/qnio
+TEST_TARGET_DIR = /usr/local/bin
+LIBRARY      = /usr/lib64
 
 OPTFLAGS     = $(DEBUGFLAGS)
-
-HEADERS = $(shell echo include/*.h)
 
 BASE_TARGET = libqnio.so
 BASE_SOURCES = $(shell echo lib/qnio/*.c) 
@@ -26,10 +28,13 @@ TEST_OBJS = $(shell echo test/*.o lib/qnio/*.d)
 TEST_OBJECTS = $(TEST_SOURCES:.c=.o)
 -include $(TEST_SOURCES:.c=.d)
 
+debug:
+	$(MAKE) -f $(MAKEFILE) DEV2="-DDEBUG_QNIO";
+
 all: $(BASE_TARGET) $(TEST_TARGET)
 
 .c.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(DEPFLAGS) $(OPTFLAGS) -c -o $@ $<
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(DEV2) $(DEPFLAGS) $(OPTFLAGS) -c -o $@ $<
 
 $(BASE_TARGET): $(BASE_OBJECTS)
 	$(CC) $(FLAGS) $(CFLAGS) $(LDFLAGS) -o $(BASE_TARGET) $(BASE_OBJECTS)
@@ -43,3 +48,13 @@ clean:
 	\rm -f $(TEST_TARGET)
 	\rm -f $(TEST_OBJS)
 
+install: all
+	mkdir -p $(HEADERS) || exit
+	cp -f include/qnio_api.h $(HEADERS)/qnio_api.h
+	cp -f $(BASE_TARGET) $(LIBRARY)/$(BASE_TARGET)
+	cp -f $(TEST_TARGET) ${TEST_TARGET_DIR}/$(TEST_TARGET)
+
+uninstall:
+	rm -f $(HEADERS)/qnio_api.h
+	rm -f $(LIBRARY)/$(BASE_TARGET)
+	rm -f ${TEST_TARGET_DIR}/$(TEST_TARGET)

--- a/src/include/defs.h
+++ b/src/include/defs.h
@@ -234,14 +234,16 @@ void reset_write_state(struct NSWriteInfo *winfo);
 int create_and_bind(char *node, char *port);
 void clear_msg(struct qnio_msg *msg);
 
-#define nioErr(fmt, ...) {\
+#ifdef DEBUG_QNIO
+#define nioDbg(fmt, ...) {\
         time_t t = time(0); \
         char buf[9] = {0}; \
         strftime(buf, 9, "%H:%M:%S", localtime(&t)); \
         fprintf(stderr, "[%s: %lu] %d: %s():\t" fmt "\n",\
 		buf, pthread_self(), __LINE__, __FUNCTION__, ##__VA_ARGS__);\
 }
-
-#define nioDbg nioErr
+#else
+#define nioDbg(fmt, ...) ((void)0)
+#endif /* DEBUG_QNIO */
 
 #endif /* QNIOEFS_HEADER_DEFINED */

--- a/src/include/io_qnio.h
+++ b/src/include/io_qnio.h
@@ -20,15 +20,17 @@
 
 #define IO_BUF_SIZE           4603904  /* 4.4MB */
 
-#define qnioErr(...) {\
+#ifdef DEBUG_QNIO
+#define qnioDbg(...) {\
         time_t t = time(0); \
         char buf[9] = {0}; \
         strftime(buf, 9, "%H:%M:%S", localtime(&t)); \
         fprintf(stderr, "[%s: %lu] %d: %s():\t", buf, pthread_self(), __LINE__, __FUNCTION__);\
         fprintf(stderr, __VA_ARGS__);\
 }
-
-#define qnioDbg qnioErr
+#else
+#define qnioDbg(...) ((void)0)
+#endif /* DEBUG_QNIO */
 
 typedef struct iio_msg_t
 {


### PR DESCRIPTION
1) Added install/uninstall option to Makefile.
   install copies header file, qnio library, and qnio server.
   uninstall removes the above files.
2) Added debug build option. Debug messages are now printed with only debug build.
3) Added logfile option to the qnio_server. Debug messages gets redirected to this logfile.
4) Added graceful handling of SIGTERM signal.